### PR TITLE
Handle unescaped URIs with dnd-get-local-file-name

### DIFF
--- a/pdf-drop-mode.el
+++ b/pdf-drop-mode.el
@@ -184,7 +184,8 @@ doi is returned."
   ;;      (pdf-drop--process (substring uri 7))
   ;;    (error
   ;;     (pdf-drop--file-dnd-fallback uri action))))
-  (pdf-drop--process (substring uri 7)))
+  (let ((file (dnd-get-local-file-name uri)))
+    (pdf-drop--process file)))
 
 (defun pdf-drop--process (file)
   "Try to get the DOI associated to file."


### PR DESCRIPTION
Ran into an error on MacOS (12.3.1) where `pdf-drop--file-dnd-protocol` was cutting off the first two letters of the filename being being passed to `pdf-drop--process`.

That is, the file path would be "sers/localauthor/Desktop/mygreatfile.pdf" instead of "/Users/localauthor/Desktop/mygreatfile.pdf".

fyi:
GNU Emacs 29.0.50 (build 1, x86_64-apple-darwin19.6.0, NS appkit-1894.70 Version 10.15.7 (Build 19H1922)) of 2022-05-26